### PR TITLE
Use gcc:5.5 image since 5.4 isn't supported anymore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
 
     docker:
-        - image: gcc:5.4.0
+        - image: gcc:5.5
 
     steps:
       - checkout


### PR DESCRIPTION
According to https://hub.docker.com/_/gcc 5.5 is the oldest supported
version.