### PR TITLE
Automated type conversion

### DIFF
--- a/sps30-i2c/sps30.c
+++ b/sps30-i2c/sps30.c
@@ -35,7 +35,7 @@
 #include "sensirion_i2c.h"
 #include "sps_git_version.h"
 
-static const u8 SPS_I2C_ADDRESS = 0x69;
+static const uint8_t SPS_I2C_ADDRESS = 0x69;
 
 #define SPS_CMD_START_MEASUREMENT 0x0010
 #define SPS_CMD_START_MEASUREMENT_ARG 0x0300
@@ -51,7 +51,7 @@ const char *sps_get_driver_version() {
     return SPS_DRV_VERSION_STR;
 }
 
-s16 sps30_probe() {
+int16_t sps30_probe() {
     char serial[SPS_MAX_SERIAL_LEN];
 
     sensirion_i2c_init();
@@ -59,16 +59,16 @@ s16 sps30_probe() {
     return sps30_get_serial(serial);
 }
 
-s16 sps30_get_serial(char *serial) {
-    u16 i;
-    s16 ret;
+int16_t sps30_get_serial(char *serial) {
+    uint16_t i;
+    int16_t ret;
     union {
         char serial[SPS_MAX_SERIAL_LEN];
-        u16 __enforce_alignment;
+        uint16_t __enforce_alignment;
     } buffer;
 
     ret = sensirion_i2c_read_cmd(SPS_I2C_ADDRESS, SPS_CMD_GET_SERIAL,
-                                 (u16 *)buffer.serial,
+                                 (uint16_t *)buffer.serial,
                                  SENSIRION_NUM_WORDS(buffer.serial));
     if (ret != STATUS_OK)
         return ret;
@@ -83,38 +83,38 @@ s16 sps30_get_serial(char *serial) {
     return 0;
 }
 
-s16 sps30_start_measurement() {
-    const u16 arg = SPS_CMD_START_MEASUREMENT_ARG;
+int16_t sps30_start_measurement() {
+    const uint16_t arg = SPS_CMD_START_MEASUREMENT_ARG;
 
     return sensirion_i2c_write_cmd_with_args(SPS_I2C_ADDRESS,
                                              SPS_CMD_START_MEASUREMENT, &arg,
                                              SENSIRION_NUM_WORDS(arg));
 }
 
-s16 sps30_stop_measurement() {
+int16_t sps30_stop_measurement() {
     return sensirion_i2c_write_cmd(SPS_I2C_ADDRESS, SPS_CMD_STOP_MEASUREMENT);
 }
 
-s16 sps30_read_data_ready(u16 *data_ready) {
+int16_t sps30_read_data_ready(uint16_t *data_ready) {
     return sensirion_i2c_read_cmd(SPS_I2C_ADDRESS, SPS_CMD_GET_DATA_READY,
                                   data_ready, SENSIRION_NUM_WORDS(*data_ready));
 }
 
-s16 sps30_read_measurement(struct sps30_measurement *measurement) {
-    s16 ret;
-    u16 idx;
+int16_t sps30_read_measurement(struct sps30_measurement *measurement) {
+    int16_t ret;
+    uint16_t idx;
     union {
-        u16 u16[2];
-        u32 u;
-        f32 f;
+        uint16_t uint16_t[2];
+        uint32_t u;
+        float32_t f;
     } val, data[10];
 
     ret = sensirion_i2c_read_cmd(SPS_I2C_ADDRESS, SPS_CMD_READ_MEASUREMENT,
-                                 data->u16, SENSIRION_NUM_WORDS(data));
+                                 data->uint16_t, SENSIRION_NUM_WORDS(data));
     if (ret != STATUS_OK)
         return ret;
 
-    SENSIRION_WORDS_TO_BYTES(data->u16, SENSIRION_NUM_WORDS(data));
+    SENSIRION_WORDS_TO_BYTES(data->uint16_t, SENSIRION_NUM_WORDS(data));
 
     idx = 0;
     val.u = be32_to_cpu(data[idx].u);
@@ -151,27 +151,27 @@ s16 sps30_read_measurement(struct sps30_measurement *measurement) {
     return 0;
 }
 
-s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds) {
+int16_t sps30_get_fan_auto_cleaning_interval(uint32_t *interval_seconds) {
     union {
-        u16 u16[2];
-        u32 u32;
+        uint16_t uint16_t[2];
+        uint32_t uint32_t;
     } data;
-    s16 ret =
-        sensirion_i2c_read_cmd(SPS_I2C_ADDRESS, SPS_CMD_AUTOCLEAN_INTERVAL,
-                               data.u16, SENSIRION_NUM_WORDS(data.u16));
+    int16_t ret = sensirion_i2c_read_cmd(
+        SPS_I2C_ADDRESS, SPS_CMD_AUTOCLEAN_INTERVAL, data.uint16_t,
+        SENSIRION_NUM_WORDS(data.uint16_t));
     if (ret != STATUS_OK)
         return ret;
 
-    SENSIRION_WORDS_TO_BYTES(data.u16, SENSIRION_NUM_WORDS(data.u16));
-    *interval_seconds = be32_to_cpu(data.u32);
+    SENSIRION_WORDS_TO_BYTES(data.uint16_t, SENSIRION_NUM_WORDS(data.uint16_t));
+    *interval_seconds = be32_to_cpu(data.uint32_t);
 
     return 0;
 }
 
-s16 sps30_set_fan_auto_cleaning_interval(u32 interval_seconds) {
-    s16 ret;
-    const u16 data[] = {(interval_seconds & 0xFFFF0000) >> 16,
-                        (interval_seconds & 0x0000FFFF) >> 0};
+int16_t sps30_set_fan_auto_cleaning_interval(uint32_t interval_seconds) {
+    int16_t ret;
+    const uint16_t data[] = {(interval_seconds & 0xFFFF0000) >> 16,
+                             (interval_seconds & 0x0000FFFF) >> 0};
 
     ret = sensirion_i2c_write_cmd_with_args(SPS_I2C_ADDRESS,
                                             SPS_CMD_AUTOCLEAN_INTERVAL, data,
@@ -180,9 +180,9 @@ s16 sps30_set_fan_auto_cleaning_interval(u32 interval_seconds) {
     return ret;
 }
 
-s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days) {
-    s16 ret;
-    u32 interval_seconds;
+int16_t sps30_get_fan_auto_cleaning_interval_days(uint8_t *interval_days) {
+    int16_t ret;
+    uint32_t interval_seconds;
 
     ret = sps30_get_fan_auto_cleaning_interval(&interval_seconds);
     if (ret < 0)
@@ -192,11 +192,11 @@ s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days) {
     return ret;
 }
 
-s16 sps30_set_fan_auto_cleaning_interval_days(u8 interval_days) {
-    return sps30_set_fan_auto_cleaning_interval((u32)interval_days * 24 * 60 *
-                                                60);
+int16_t sps30_set_fan_auto_cleaning_interval_days(uint8_t interval_days) {
+    return sps30_set_fan_auto_cleaning_interval((uint32_t)interval_days * 24 *
+                                                60 * 60);
 }
 
-s16 sps30_reset() {
+int16_t sps30_reset() {
     return sensirion_i2c_write_cmd(SPS_I2C_ADDRESS, SPS_CMD_RESET);
 }

--- a/sps30-i2c/sps30.h
+++ b/sps30-i2c/sps30.h
@@ -41,16 +41,16 @@ extern "C" {
 #define SPS_MAX_SERIAL_LEN 32
 
 struct sps30_measurement {
-    f32 mc_1p0;
-    f32 mc_2p5;
-    f32 mc_4p0;
-    f32 mc_10p0;
-    f32 nc_0p5;
-    f32 nc_1p0;
-    f32 nc_2p5;
-    f32 nc_4p0;
-    f32 nc_10p0;
-    f32 typical_particle_size;
+    float32_t mc_1p0;
+    float32_t mc_2p5;
+    float32_t mc_4p0;
+    float32_t mc_10p0;
+    float32_t nc_0p5;
+    float32_t nc_1p0;
+    float32_t nc_2p5;
+    float32_t nc_4p0;
+    float32_t nc_10p0;
+    float32_t typical_particle_size;
 };
 
 /**
@@ -68,7 +68,7 @@ const char *sps_get_driver_version(void);
  *
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_probe();
+int16_t sps30_probe();
 
 /**
  * sps30_get_serial() - retrieve the serial number
@@ -79,7 +79,7 @@ s16 sps30_probe();
  *          terminated). Must be at least SPS_MAX_SERIAL_LEN long.
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_get_serial(char *serial);
+int16_t sps30_get_serial(char *serial);
 
 /**
  * sps30_start_measurement() - start measuring
@@ -89,14 +89,14 @@ s16 sps30_get_serial(char *serial);
  *
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_start_measurement();
+int16_t sps30_start_measurement();
 
 /**
  * sps30_stop_measurement() - stop measuring
  *
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_stop_measurement();
+int16_t sps30_stop_measurement();
 
 /**
  * sps30_read_datda_ready() - reads the current data-ready flag
@@ -107,7 +107,7 @@ s16 sps30_stop_measurement();
  * @data_ready: Memory where the data-ready flag (0|1) is stored.
  * Return:      0 on success, an error code otherwise
  */
-s16 sps30_read_data_ready(u16 *data_ready);
+int16_t sps30_read_data_ready(uint16_t *data_ready);
 
 /**
  * sps30_read_measurement() - read a measurement
@@ -116,7 +116,7 @@ s16 sps30_read_data_ready(u16 *data_ready);
  *
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_read_measurement(struct sps30_measurement *measurement);
+int16_t sps30_read_measurement(struct sps30_measurement *measurement);
 
 /**
  * sps30_get_fan_auto_cleaning_interval() - read the current(*) auto-cleaning
@@ -133,7 +133,7 @@ s16 sps30_read_measurement(struct sps30_measurement *measurement);
  * @interval_seconds:   Memory where the interval in seconds is stored
  * Return:              0 on success, an error code otherwise
  */
-s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds);
+int16_t sps30_get_fan_auto_cleaning_interval(uint32_t *interval_seconds);
 
 /**
  * sps30_set_fan_auto_cleaning_interval() - set the current auto-cleaning
@@ -143,7 +143,7 @@ s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds);
  *                      interval, 0 to disable auto cleaning
  * Return:              0 on success, an error code otherwise
  */
-s16 sps30_set_fan_auto_cleaning_interval(u32 interval_seconds);
+int16_t sps30_set_fan_auto_cleaning_interval(uint32_t interval_seconds);
 
 /**
  * sps30_get_fan_auto_cleaning_interval_days() - convenience function to read
@@ -164,7 +164,7 @@ s16 sps30_set_fan_auto_cleaning_interval(u32 interval_seconds);
  * @interval_days:  Memory where the interval in days is stored
  * Return:          0 on success, an error code otherwise
  */
-s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days);
+int16_t sps30_get_fan_auto_cleaning_interval_days(uint8_t *interval_days);
 
 /**
  * sps30_set_fan_auto_cleaning_interval_days() - convenience function to set the
@@ -174,7 +174,7 @@ s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days);
  *                  disable auto cleaning
  * Return:          0 on success, an error code otherwise
  */
-s16 sps30_set_fan_auto_cleaning_interval_days(u8 interval_days);
+int16_t sps30_set_fan_auto_cleaning_interval_days(uint8_t interval_days);
 
 /**
  * sps30_reset() - reset the SGP30
@@ -188,7 +188,7 @@ s16 sps30_set_fan_auto_cleaning_interval_days(u8 interval_days);
  *
  * Return:          0 on success, an error code otherwise
  */
-s16 sps30_reset();
+int16_t sps30_reset();
 
 #ifdef __cplusplus
 }

--- a/sps30-i2c/sps30_example_usage.c
+++ b/sps30-i2c/sps30_example_usage.c
@@ -44,10 +44,10 @@
 int main(void) {
     struct sps30_measurement m;
     char serial[SPS_MAX_SERIAL_LEN];
-    u8 auto_clean_days = 4;
-    u32 auto_clean;
-    u16 data_ready;
-    s16 ret;
+    uint8_t auto_clean_days = 4;
+    uint32_t auto_clean;
+    uint16_t data_ready;
+    int16_t ret;
 
     /* Busy loop for initialization, because the main loop does not work without
      * a sensor.

--- a/sps30-i2c/test_projects/Arduino/arduino_sps30_example/arduino_sps30_example.ino
+++ b/sps30-i2c/test_projects/Arduino/arduino_sps30_example/arduino_sps30_example.ino
@@ -42,7 +42,7 @@ void setup() {
 
 void loop() {
     struct sps30_measurement measurement;
-    s16 ret;
+    int16_t ret;
 
     while (sps30_probe() != 0) {
         Serial.write("probe failed\n");


### PR DESCRIPTION
This patch includes the changes from the following commands:

    find . -type f \
        \( -name '*\.[ch]' -o -name '*\.cpp' -o -name '*\.ino' \) -print0 \
        | xargs -0 sed -i \
        -e 's/\bu\([0-9]\{1,2\}\)\b/uint\1_t/g' \
        -e 's/\bs\([0-9]\{1,2\}\)\b/int\1_t/g' \
        -e 's/\bf32\b/float32_t/g'
    make style-fix

This commit updates embedded-common