### PR TITLE
Move sensirion_i2c_init from probe() to example

### DIFF
--- a/sps30-i2c/sps30.c
+++ b/sps30-i2c/sps30.c
@@ -54,8 +54,6 @@ const char *sps_get_driver_version() {
 int16_t sps30_probe() {
     char serial[SPS_MAX_SERIAL_LEN];
 
-    sensirion_i2c_init();
-
     return sps30_get_serial(serial);
 }
 

--- a/sps30-i2c/sps30_example_usage.c
+++ b/sps30-i2c/sps30_example_usage.c
@@ -49,6 +49,9 @@ int main(void) {
     uint16_t data_ready;
     int16_t ret;
 
+    /* Initialize I2C bus */
+    sensirion_i2c_init();
+
     /* Busy loop for initialization, because the main loop does not work without
      * a sensor.
      */


### PR DESCRIPTION
This constitutes an interface change since the bus initialization now
has to be performed manually.