### PR TITLE
Add delay to fix possible I2C write fail

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,0 @@
-Andreas Brauchli <andreas.brauchli@sensirion.com>
-Sven Gruebel <sven.gruebel@sensirion.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                - sps30_set_fan_auto_cleaning_interval_days
                - sps30_start_manual_fan_cleaning
                - sps30_reset
+ * [`removed`] Remove the `AUTHORS` file from the driver and the
+               `embedded-common` submodule, as it adds more noise than benefit.
+               The contributors can be found in the git log.
 
 ## [2.0.0] - 2019-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                types as names (e.g. `uint16_t uint16_t = 5`)
  * [`changed`] Update submodule to increase timeout while clock stretching in
                software I2C mode
+ * [`fixed`]   Add a delay to the following commands in order to fix an I2C
+               write fail that might happen when the sensor is still busy
+               processing the command when the next command arrives:
+               - sps30_start_measurement
+               - sps30_stop_measurement
+               - sps30_set_fan_auto_cleaning_interval
+               - sps30_set_fan_auto_cleaning_interval_days
+               - sps30_start_manual_fan_cleaning
+               - sps30_reset
 
 ## [2.0.0] - 2019-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * [`removed`] Remove the `AUTHORS` file from the driver and the
                `embedded-common` submodule, as it adds more noise than benefit.
                The contributors can be found in the git log.
+ * [`fixed`]   Copy correct `CHANGELOG.md` and `LICENSE` files to target
+               locations when running the `release` target of the driver's root
+               Makefile.
 
 ## [2.0.0] - 2019-05-13
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ $(release_drivers): sps-common/sps_git_version.c
 	cp -r embedded-common/* "$${pkgdir}" && \
 	cp -r sps-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
+	cp CHANGELOG.md LICENSE "$${pkgdir}" && \
 	echo 'sps_driver_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sensirion_common_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sps_common_dir = .' >> $${pkgdir}/user_config.inc && \

--- a/sps30-i2c/sps30.c
+++ b/sps30-i2c/sps30.c
@@ -45,7 +45,8 @@
 #define SPS_CMD_GET_SERIAL 0xd033
 #define SPS_CMD_RESET 0xd304
 #define SPS_CMD_START_MANUAL_FAN_CLEANING 0x5607
-#define SPS_WRITE_DELAY_US 20000
+#define SPS_CMD_DELAY_USEC 10000
+#define SPS_WRITE_DELAY_USEC 15000
 
 const char *sps_get_driver_version() {
     return SPS_DRV_VERSION_STR;
@@ -95,13 +96,20 @@ int16_t sps30_get_serial(char *serial) {
 int16_t sps30_start_measurement() {
     const uint16_t arg = SPS_CMD_START_MEASUREMENT_ARG;
 
-    return sensirion_i2c_write_cmd_with_args(SPS30_I2C_ADDRESS,
-                                             SPS_CMD_START_MEASUREMENT, &arg,
-                                             SENSIRION_NUM_WORDS(arg));
+    int16_t ret = sensirion_i2c_write_cmd_with_args(
+        SPS30_I2C_ADDRESS, SPS_CMD_START_MEASUREMENT, &arg,
+        SENSIRION_NUM_WORDS(arg));
+
+    sensirion_sleep_usec(SPS_CMD_DELAY_USEC);
+
+    return ret;
 }
 
 int16_t sps30_stop_measurement() {
-    return sensirion_i2c_write_cmd(SPS30_I2C_ADDRESS, SPS_CMD_STOP_MEASUREMENT);
+    int16_t ret =
+        sensirion_i2c_write_cmd(SPS30_I2C_ADDRESS, SPS_CMD_STOP_MEASUREMENT);
+    sensirion_sleep_usec(SPS_CMD_DELAY_USEC);
+    return ret;
 }
 
 int16_t sps30_read_data_ready(uint16_t *data_ready) {
@@ -186,7 +194,7 @@ int16_t sps30_set_fan_auto_cleaning_interval(uint32_t interval_seconds) {
     ret = sensirion_i2c_write_cmd_with_args(SPS30_I2C_ADDRESS,
                                             SPS_CMD_AUTOCLEAN_INTERVAL, data,
                                             SENSIRION_NUM_WORDS(data));
-    sensirion_sleep_usec(SPS_WRITE_DELAY_US);
+    sensirion_sleep_usec(SPS_WRITE_DELAY_USEC);
     return ret;
 }
 
@@ -215,7 +223,7 @@ int16_t sps30_start_manual_fan_cleaning() {
     if (ret)
         return ret;
 
-    sensirion_sleep_usec(SPS_WRITE_DELAY_US);
+    sensirion_sleep_usec(SPS_CMD_DELAY_USEC);
     return 0;
 }
 

--- a/sps30-i2c/sps30.h
+++ b/sps30-i2c/sps30.h
@@ -43,6 +43,7 @@ extern "C" {
 #define SPS30_I2C_ADDRESS 0x69
 #define SPS30_MAX_SERIAL_LEN 32
 #define SPS30_MEASUREMENT_DURATION_USEC 1000000 /* 1s measurement intervals */
+#define SPS30_RESET_DELAY_USEC 50000 /* 50ms delay after resetting the sensor */
 
 struct sps30_measurement {
     float32_t mc_1p0;
@@ -205,6 +206,10 @@ int16_t sps30_start_manual_fan_cleaning();
  *
  * The sensor reboots to the same state as before the reset but takes a few
  * seconds to resume measurements.
+ *
+ * The caller should wait at least SPS30_RESET_DELAY_USEC microseconds before
+ * interacting with the sensor again in order for the sensor to restart.
+ * Interactions with the sensor without this delay might fail.
  *
  * Note that the interface-select configuration is reinterpreted, thus Pin 4
  * must be pulled to ground during the reset period for the sensor to remain in


### PR DESCRIPTION
For the following commands, an I2C write fail might occur when the
sensor is still processing the command and a new command is sent:

 - sps30_start_measurement
 - sps30_stop_measurement
 - sps30_set_fan_auto_cleaning_interval
 - sps30_set_fan_auto_cleaning_interval_days
 - sps30_start_manual_fan_cleaning
 - sps30_reset

A delay of 10ms is added to these commands (15ms for
sps30_set_fan_auto_cleaning_interval and
sps30_set_fan_auto_cleaning_interval_days, 50ms for sps30_reset) to give
the sensor enough time to process these commands