### PR TITLE
SPS30: Fix timing on cleaning interval reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`fixed`]   Fix timing with `sps30_get_fan_auto_cleaning_interval` and
+               `sps30_get_fan_auto_cleaning_interval_days` which could result in
+               read failures.
+
 ## [3.0.0] - 2019-11-20
 
  * [`fixed`]   Improved compatibility with C++ compilers

--- a/sps30-i2c/sps30.c
+++ b/sps30-i2c/sps30.c
@@ -172,9 +172,9 @@ int16_t sps30_get_fan_auto_cleaning_interval(uint32_t *interval_seconds) {
         uint16_t u16_value[2];
         uint32_t u32_value;
     } data;
-    int16_t ret = sensirion_i2c_read_cmd(
-        SPS30_I2C_ADDRESS, SPS_CMD_AUTOCLEAN_INTERVAL, data.u16_value,
-        SENSIRION_NUM_WORDS(data.u16_value));
+    int16_t ret = sensirion_i2c_delayed_read_cmd(
+        SPS30_I2C_ADDRESS, SPS_CMD_AUTOCLEAN_INTERVAL, SPS_CMD_DELAY_USEC,
+        data.u16_value, SENSIRION_NUM_WORDS(data.u16_value));
     if (ret != STATUS_OK)
         return ret;
 


### PR DESCRIPTION
Adjust timing with `sps30_get_fan_auto_cleaning_interval` and
`sps30_get_fan_auto_cleaning_interval_days` which could result in read
failures.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [x] Changelog updated
 - [ ] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
