### PR TITLE
Use sensirion Docker image for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - run: make prepare
       - run: make
       - run: make clean
+      - run: make style-check
       - run: make release
       - run:
           name: build stub release drivers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,17 +2,13 @@ version: 2
 
 jobs:
   build:
-
     docker:
-        - image: gcc:5.5
-
+      - image: sensirion/embedded-ci:2.0.0
     steps:
       - checkout
       - run:
           name: update common repo
           command: git submodule update --init
-      - run: apt update
-      - run: apt install -y zip
       - run: make prepare
       - run: make
       - run: make clean
@@ -33,14 +29,12 @@ jobs:
                make clean)
   deploy:
     docker:
-      - image: gcc:5.5
+      - image: sensirion/embedded-ci:2.0.0
     steps:
       - checkout
       - run:
           name: update common repo
           command: git submodule update --init
-      - run: apt update
-      - run: apt install -y zip
       - run: make release
       - run:
           name: Move zip files to artifact directory

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ style-fix:
 		echo "Refusing to run on dirty git state. Commit your changes first."; \
 		exit 1; \
 	fi; \
-	git ls-files | grep -e '\.\(c\|h\|cpp\)$$' | xargs clang-format -i -style=file;
+	git ls-files | grep -e '\.\(c\|h\|cpp\)$$' | xargs clang-format-6.0 -i -style=file;
 
 style-check: style-fix
 	@if [ $$(git status --porcelain -uno 2> /dev/null | wc -l) -gt "0" ]; \


### PR DESCRIPTION
Saves some time installing dependencies and allows to check formatting.

Check the following:

 - [na] Breaking changes marked in commit message
 - [na] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [na] Tested on actual hardware
