### PR TITLE
 Change makefile to only incude needed files from embedded-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * [`changed`] Update timings according to datasheet
  * [`changed`] Use configuration independent endianness conversions: no need to
                define `SENSIRION_BIG_ENDIAN` anymore.
+ * [`changed`] Makefile to only include needed files from embedded-common
 
 ## [3.0.1] - 2019-11-26
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,12 @@ $(release_drivers): sps-common/sps_git_version.c
 	export pkgname="$${driver}-$${tag}" && \
 	export pkgdir="release/$${pkgname}" && \
 	rm -rf "$${pkgdir}" && mkdir -p "$${pkgdir}" && \
-	cp -r embedded-common/* "$${pkgdir}" && \
+	cp -r embedded-common/hw_i2c/ "$${pkgdir}" && \
+	cp -r embedded-common/sw_i2c/ "$${pkgdir}" && \
+	cp embedded-common/sensirion_arch_config.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.c "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_i2c.h "$${pkgdir}" && \
 	cp -r sps-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
 	cp CHANGELOG.md LICENSE "$${pkgdir}" && \


### PR DESCRIPTION
Change makefile to only include the needed parts of embedded-common
in the release package.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [x] Changelog updated
 - [na] Code style cleaned (ran `make style-fix`)
 - [na] Tested on actual hardware
